### PR TITLE
When sorting use statement ignore case

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -158,8 +158,8 @@ class Resolver {
 
         let sorted = useStatements.slice().sort((a, b) => {
             if (this.config('sortAlphabetically')) {
-                if (a.text < b.text) return -1;
-                if (a.text > b.text) return 1;
+                if (a.text.toLowerCase() < b.text.toLowerCase()) return -1;
+                if (a.text.toLowerCase() > b.text.toLowerCase()) return 1;
                 return 0;
             } else {
                 return a.text.length - b.text.length;


### PR DESCRIPTION
Some of the projects that we work with have ( Legacy or/and Modern ) might have a mix of imports. 

```
    use ZEND_ONE;
    use BClass;
    use AClass;
```

Current sorting mechanism sorts in two layers stacking the Uppercase class names on top of the other. Ideally sorting should ignore the case and sort accordingly.

```
    use AClass;
    use BClass;
    use ZEND_ONE;
```

This PR will allow you to do that for anyone using the Alphabetical sorting option. 