### PR TITLE
chore: break for-loop when already done

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -213,6 +213,12 @@ class Resolver {
                 throw new Error('$(issue-opened)  Class already imported.');
             }
 
+            // break if all declarations were found
+            if (declarationLines.PHPTag && declarationLines.namespace &&
+                declarationLines.useStatement && declarationLines.class) {
+                break;
+            }
+
             if (text.startsWith('<?php')) {
                 declarationLines.PHPTag = line + 1;
             } else if (text.startsWith('namespace ')) {


### PR DESCRIPTION
Skip checking of other lines when all declarations have been found. This increases the performance on big files.