### PR TITLE
Add alphabetical fallback when imports are the same length.

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -244,6 +244,10 @@ module.exports = class Resolver {
                 if (a.text.toLowerCase() > b.text.toLowerCase()) return 1;
                 return 0;
             } else {
+                if (a.text.length == b.text.length) {
+                    if (a.text.toLowerCase() < b.text.toLowerCase()) return -1;
+                    if (a.text.toLowerCase() > b.text.toLowerCase()) return 1;
+                }
                 return a.text.length - b.text.length;
             }
         });


### PR DESCRIPTION
When sorting by length, the sort order of two import statements of the same length is undetermined. You can run the sort multiple times on the same file, and the order of same length statements may change each time.

This PR adds the alphabetic sort as a fallback. So, statements will be sorted first by length, and then equal length statements will be sorted alphabetically.

Now when sorting imports, the result will always be the same.