### PR TITLE
Add natural sorting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can override these default settings according to your needs.
     "namespaceResolver.autoSort": true,                 // Auto sort after imports
     "namespaceResolver.sortOnSave": false,              // Auto sort when a file is saved
     "namespaceResolver.sortAlphabetically": false,      // Sort imports in alphabetical order instead of line length
+    "namespaceResolver.sortNatural": false,             // Sort imports using a 'natural order' algorithm
     "namespaceResolver.leadingSeparator": true          // Expand class with leading namespace separator
 }
 ```

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
                     "default": false,
                     "description": "Sort imports in alphabetical order instead of line length"
                 },
+                "namespaceResolver.sortNatural": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Sort imports using a 'natural order' algorithm"
+                },
                 "namespaceResolver.leadingSeparator": {
                     "type": "boolean",
                     "default": true,
@@ -134,5 +139,8 @@
     },
     "devDependencies": {
         "vscode": "^1.0.0"
+    },
+    "dependencies": {
+        "node-natural-sort": "^0.8.6"
     }
 }

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -241,8 +241,8 @@ module.exports = class Resolver {
         if (useStatements.length <= 1) {
             throw new Error('$(issue-opened)  Nothing to sort.');
             return;
-        }       
-        
+        }
+
         let sortFunction = (a, b) => {
             if (this.config('sortAlphabetically')) {
                 if (a.text.toLowerCase() < b.text.toLowerCase()) return -1;


### PR DESCRIPTION
Some frameworks phpcs sniffs require natural sorting of use statements (cakephp for example). This change adds an option to sort these just like that ( in php this can be done using natcasesort() )