### PR TITLE
generate namespace for current file

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "onCommand:namespaceResolver.expand",
         "onCommand:namespaceResolver.sort",
         "onCommand:namespaceResolver.highlightNotImported",
-        "onCommand:namespaceResolver.highlightNotUsed"
+        "onCommand:namespaceResolver.highlightNotUsed",
+        "onCommand:namespaceResolver.generateNamespace"
     ],
     "main": "./src/extension",
     "icon": "images/icon.png",
@@ -72,6 +73,12 @@
                     "command": "namespaceResolver.highlightNotUsed",
                     "alt": "namespaceResolver.highlightNotUsed",
                     "group": "0_namespace_resolver@6"
+                },
+                {
+                    "when": "resourceLangId == php",
+                    "command": "namespaceResolver.generateNamespace",
+                    "alt": "namespaceResolver.generateNamespace",
+                    "group": "0_namespace_resolver@7"
                 }
             ]
         },
@@ -140,6 +147,10 @@
             {
                 "title": "Highlight Not Used Classes",
                 "command": "namespaceResolver.highlightNotUsed"
+            },
+            {
+                "title": "Generate namespace for this file",
+                "command": "namespaceResolver.generateNamespace"
             }
         ],
         "keybindings": [
@@ -171,6 +182,11 @@
             {
                 "command": "namespaceResolver.highlightNotUsed",
                 "key": "ctrl+alt+u",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "namespaceResolver.generateNamespace",
+                "key": "ctrl+alt+g",
                 "when": "editorTextFocus"
             }
         ]

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -617,11 +617,17 @@ class Resolver {
 
             let namespaceBase = Object.keys(psr4)[0];
             let baseDir = psr4[namespaceBase];
+            namespaceBase = namespaceBase.replace(/\\/, '');
 
             let namespace = currentPath.split(baseDir);
-            namespace = namespace[1];
-            namespace = namespace.replace(/\//g, '\\');
-            namespace = namespaceBase.replace(/\\/, '') + namespace;
+            if (namespace[1]) {
+                namespace = namespace[1]
+                namespace = namespace.replace(/\//g, '\\');
+                namespace = namespace.replace(/^\\/, '');
+                namespace = namespaceBase + '\\' + namespace;
+            } else {
+                namespace = namespaceBase;
+            }
             namespace = 'namespace ' + namespace + ';' + "\n"
 
             this.activeEditor().edit(textEdit => {

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -601,11 +601,20 @@ class Resolver {
         let currentFile = this.activeEditor().document.fileName;
         let currentPath = currentFile.substr(0, currentFile.lastIndexOf('/'));
         let composerFile = await vscode.workspace.findFiles('composer.json');
+
+        if (!composerFile.length) {
+            return this.showErrorMessage('No composer.json file found, automatic namespace generation failed');
+        }
+
         composerFile = composerFile.pop().path;
 
         vscode.workspace.openTextDocument(composerFile).then((document) => {
             let composerJson = JSON.parse(document.getText());
             let psr4 = composerJson.autoload['psr-4'];
+            if (psr4 === undefined) {
+                return this.showErrorMessage('No psr-4 key in composer.json autoload object, automatic namespace generation failed');
+            }
+
             let namespaceBase = Object.keys(psr4)[0];
             let baseDir = psr4[namespaceBase];
 
@@ -619,10 +628,6 @@ class Resolver {
                 textEdit.insert(new vscode.Position(1, 0), namespace);
             });
         });
-    }
-
-    traversePath(path) {
-
     }
 }
 

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -596,6 +596,20 @@ class Resolver {
     showErrorMessage(message) {
         this.showMessage(message, true);
     }
+
+    async generateNamespace() {
+        let namespace = this.activeEditor().document.fileName.split('/src/');
+        namespace = namespace[1].substring(0, namespace[1].lastIndexOf('/'));
+        namespace = namespace.replace('\/', '\\');
+        if (namespace.substring(0, 4) != 'App\\') {
+            namespace = 'App\\' + namespace;
+        }
+        namespace = 'namespace ' + namespace + ';' + "\n"
+
+        this.activeEditor().edit(textEdit => {
+            textEdit.insert(new vscode.Position(1, 0), namespace);
+        });
+    }
 }
 
 module.exports = Resolver;

--- a/src/extension.js
+++ b/src/extension.js
@@ -40,6 +40,10 @@ function activate(context) {
         vscode.commands.registerCommand('namespaceResolver.highlightNotUsed', () => resolver.highlightNotUsed())
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand('namespaceResolver.generateNamespace', () => resolver.generateNamespace())
+    );
+
     context.subscriptions.push(vscode.workspace.onWillSaveTextDocument((event) => {
         if (
             event.document.languageId === 'php' &&


### PR DESCRIPTION
This is a more generic solution for fix #22 than the previous PR. However if multiple namespaces declared in the composer.json psr-4 entry the generation will fail.

I do not know how often we can find multiple entries there, none of my projects has. In this case the extension could offer a select (similar to what we have for non unique class names). I would leave this now like this and see if you get any bug reports...