### PR TITLE
Trail only the latest double backslash in namespaceBase

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -619,7 +619,7 @@ class Resolver {
             let namespaceBase = Object.keys(psr4)[0];
             let baseDir = psr4[namespaceBase];
 
-            namespaceBase = namespaceBase.replace(/\\/, '');
+            namespaceBase = namespaceBase.replace(/\\$/, '');
 
             let namespace = currentPath.split(baseDir);
 


### PR DESCRIPTION
Psr4 supports deep namespace base.

Currently with this example : 
```json
{
    "autoload": {
        "psr-4": {
            "Vendor\\App\\": "src/"
        }
    }
}
```

Generating namespace will display : `VendorApp\MyClass` instead of `Vendor\App\MyClass`