### PR TITLE
get classes used with "instanceof" operator

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -44,6 +44,7 @@ class Resolver {
         phpClasses = phpClasses.concat(this.getFromFunctionParameters(text));
         phpClasses = phpClasses.concat(this.getInitializedWithNew(text));
         phpClasses = phpClasses.concat(this.getFromStaticCalls(text));
+        phpClasses = phpClasses.concat(this.getFromInstanceofOperator(text));
 
         return phpClasses.filter((v, i, a) => a.indexOf(v) === i);
     }
@@ -95,6 +96,18 @@ class Resolver {
 
     getFromStaticCalls(text) {
         let regex = /([A-Z][A-Za-z0-9\-\_]*)::/gm;
+        let matches = [];
+        let phpClasses = [];
+
+        while (matches = regex.exec(text)) {
+            phpClasses.push(matches[1]);
+        }
+
+        return phpClasses;
+    }
+
+    getFromInstanceofOperator(text) {
+        let regex = /instanceof ([A-Z_][A-Za-z0-9\_]*)/gm;
         let matches = [];
         let phpClasses = [];
 


### PR DESCRIPTION
Excludes classes used with `instanceof` operator from highlighting.

```php
use Foobar;

if ($foobar instanceof Foobar) {
    //
}
```