### PR TITLE
Insert newline before namespace

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -693,7 +693,7 @@ class Resolver {
                 namespace = namespaceBase;
             }
 
-            namespace = 'namespace ' + namespace + ';' + "\n"
+            namespace = "\nnamespace " + namespace + ";\n";
 
             let declarationLines;
 


### PR DESCRIPTION
### Summary

Inserts a newline before generated namespace for cleaner code style.

**Before:**
![image](https://github.com/MehediDracula/PHP-Namespace-Resolver/assets/35382935/7b4dcec3-7065-40cd-98bd-c2e31dcb1b9d)

**After:**
![image](https://github.com/MehediDracula/PHP-Namespace-Resolver/assets/35382935/de03428a-6234-4abd-ab4d-846e94f0d9a0)

