### PR TITLE
Fix false "class not used" for `@use PHPDoc` annotations

### DIFF
--- a/src/core/PhpClassDetector.ts
+++ b/src/core/PhpClassDetector.ts
@@ -284,8 +284,8 @@ export class PhpClassDetector {
                 results.push(...this.extractClassNamesFromDocType(match[1]));
             }
 
-            // @extends Type<...>, @implements Type<...>
-            const extendsRegex = /@(?:extends|implements|template-extends|template-implements)\s+(\S+)/gm;
+            // @extends Type<...>, @implements Type<...>, @use Trait<...> (and template-* variants)
+            const extendsRegex = /@(?:extends|implements|use|template-extends|template-implements|template-use)\s+(\S+)/gm;
             while ((match = extendsRegex.exec(block)) !== null) {
                 results.push(...this.extractClassNamesFromDocType(match[1]));
             }

--- a/src/test/PhpClassDetector.test.ts
+++ b/src/test/PhpClassDetector.test.ts
@@ -495,6 +495,13 @@ class Foo extends Bar {
             assert.ok(result.includes('Post'));
         });
 
+        it('should detect @use trait types (generic trait import)', () => {
+            const text = `/** @use HasFactory<UserFactory> */`;
+            const result = detector.getFromPhpDoc(text);
+            assert.ok(result.includes('HasFactory'));
+            assert.ok(result.includes('UserFactory'));
+        });
+
         it('should detect @template of constraint', () => {
             const text = `/**
  * @template T of Model


### PR DESCRIPTION
`getFromPhpDoc()` didn't recognize the `@use` tag (e.g. `/** @use HasFactory<UserFactory> */`), so class names referenced only inside it — like the generic argument in Laravel's `HasFactory<Model>` pattern — were never counted as "used".

This caused the extension to incorrectly flag their `use` imports as unused.

Extend the `@extends/@implements` PHPDoc regex to also match `@use` and `@template-use`.